### PR TITLE
Add mentioning of baseUrl to readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,14 @@ For all methods above you can adjust settings in `configuration.yml`. By default
 | **`downloadOriginal`**             | Boolean |      `true`       | Enable/disable original document downloading                                                                                                 |
 | **`downloadSigned`**               | Boolean |      `true`       | Enable/disable signed document downloading                                                                                                   | 
 
+## Troubleshooting
+### How to set custom baseURL
+BaseURL is fetched from address bar however you can set custom baseURL by adding *forRoot* parameter at [app.module.ts](https://github.com/groupdocs-signature/GroupDocs.Signature-for-.NET-WebForms/blob/master/src/client/apps/signature/src/app/app.module.ts#L10)
+
+**Example:**
+```js
+SignatureModule.forRoot("http://localhost:8080")
+```
 
 ## License
 The MIT License (MIT). 

--- a/src/client/apps/signature/src/app/app.module.ts
+++ b/src/client/apps/signature/src/app/app.module.ts
@@ -7,7 +7,7 @@ import { SignatureModule } from "@groupdocs.examples.angular/signature";
 @NgModule({
   declarations: [AppComponent],
   imports: [BrowserModule,
-    SignatureModule.forRoot("http://localhost:8080")],
+    SignatureModule],
   providers: [],
   bootstrap: [AppComponent]
 })


### PR DESCRIPTION
Replicated changes from groupdocs-viewer/GroupDocs.Viewer-for-.NET-WebForms#85.